### PR TITLE
Teardown fragment after routing

### DIFF
--- a/tests/unit/test-router.js
+++ b/tests/unit/test-router.js
@@ -31,6 +31,11 @@ define([
       AppRouter.prototype.after.restore();
       AppRouter.prototype.before.restore();
       AppRouter.prototype.showLogin.restore();
+
+      // Get rid of the fragment so reloading doesn't
+      // start the tests at a different entry point.
+      window.location.replace("#");
+      history.replaceState({}, '', window.location.href.slice(0, -1));
     });
 
     test('Should call before', function(){


### PR DESCRIPTION
Makes sure there's no fragment after tests. This is just cleaner if you load /unittests in your browser and reload it.
