### PR TITLE
Hookup API for pin state and mock it for testing (bug 986100)

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -21,4 +21,6 @@ module.exports = {
   test: {
     port: 7778,
   },
+
+  showClientConsole: false
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "js-beautify": "^1.4.2",
     "mocha-phantomjs": "~3.3.2",
     "nunjucks": "~1.0.1",
-    "underscore": "~1.6.0"
+    "underscore": "^1.6.0"
   },
   "scripts": {
     "test": "node -e \"require('grunt').cli()\" null test",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -7,17 +7,25 @@ require(['config'], function(config) {
   // Main Entry point of the app.
   require([
     'backbone',
-    'id',
     'i18n',
+    'id',
+    'jquery',
     'log',
     'models/user',
     'router',
     'utils',
     'views/throbber',
-  ], function(Backbone, id, i18n, log, UserModel, router, utils, throbber){
+  ], function(Backbone, i18n, id, $, log, UserModel, router, utils, throbber){
 
     window.app = {};
     var console = log('app');
+
+    // Common ajax settings.
+    $.ajaxSetup({
+      headers: {
+        "X-CSRFToken": $('meta[name=csrf]').attr('content')
+      }
+    });
 
     function initialize() {
       console.log('I AM SPARTACUS!');
@@ -28,6 +36,8 @@ require(['config'], function(config) {
       app.user = new UserModel();
       app.router = new router.AppRouter();
       Backbone.history.start({pushState: true, root: app.router.root});
+      // Start identity watch.
+      app.user.watchIdentity();
     }
 
     // Require locale then run init.

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -53,11 +53,18 @@ define([
     },
 
     before: function() {
-      // Always run id.watch.
-      app.user.checkAuth();
-      // Check login state and prevent routing if unknown.
-      if (app.user.get('logged_in') !== true && Backbone.history.fragment !== 'login') {
-        console.log('Preventing navigation as logged_in state is unknown and not login view.');
+      // If logged_in state hasn't yet been set we need to prevent
+      // routing until it is.
+      if (app.user.get('logged_in') === null) {
+        console.log('Preventing navigation as logged_in state is unknown.');
+        this.navigate('', {replace: true});
+        return false;
+      }
+      // If logged_in state is false then we need to always show the login page.
+      // assuming that's not where we already are.
+      if (app.user.get('logged_in') === false && Backbone.history.fragment !== 'login') {
+        console.log('Not login page and logged_out so navigating to /login');
+        this.navigate('/login', {trigger: true});
         return false;
       }
     },

--- a/public/js/views/base.js
+++ b/public/js/views/base.js
@@ -35,6 +35,12 @@ define([
       this.$el.html(this.template(template, data));
       console.log('Replacing $el with rendered content');
       return this;
+    },
+    clear: function clear() {
+      // Remote the content in the view.
+      this.$el.empty();
+      // Disconnect the view's event handlers.
+      this.unbind();
     }
   });
   return BaseView;

--- a/public/js/views/create-pin.js
+++ b/public/js/views/create-pin.js
@@ -1,4 +1,9 @@
-define(['views/base', 'log', 'lib/pin'], function(BaseView, log, pin){
+define([
+  'lib/pin',
+  'log',
+  'views/base',
+  'views/throbber'
+], function(pin, log, BaseView, throbber){
   var console = log('view', 'create-pin');
   var CreatePinView = BaseView.extend({
     render: function(){
@@ -6,6 +11,7 @@ define(['views/base', 'log', 'lib/pin'], function(BaseView, log, pin){
       this.setTitle(this.gettext('Create Pin'));
       this.renderTemplate('create-pin.html');
       pin.init();
+      throbber.hide();
       return this;
     }
   });

--- a/public/js/views/enter-pin.js
+++ b/public/js/views/enter-pin.js
@@ -1,4 +1,9 @@
-define(['views/base', 'log', 'lib/pin', 'views/throbber'], function(BaseView, log, pin, throbber){
+define([
+  'lib/pin',
+  'log',
+  'views/base',
+  'views/throbber'
+], function(pin, log, BaseView, throbber){
   var console = log('view', 'enter-pin');
   var EnterPinView = BaseView.extend({
     render: function(){

--- a/public/js/views/throbber.js
+++ b/public/js/views/throbber.js
@@ -2,13 +2,14 @@ define(['jquery', 'views/base', 'log'], function($, BaseView, log){
 
   var console = log('view', 'throbber');
   var ThrobberView = BaseView.extend({
-    el: $('#progress'),
+    el: '#progress',
+    $el: $('#progress'),
     render: function(msg){
-      console.log('rendering view');
+      console.log('rendering throbber');
       this.setTitle(msg || this.gettext('Loading...'));
       this.renderTemplate('throbber.html', {msg: msg || this.gettext('Loading...')});
       return this;
-    }
+    },
   });
 
   var throbberView = new ThrobberView();
@@ -20,7 +21,7 @@ define(['jquery', 'views/base', 'log'], function($, BaseView, log){
     },
     hide: function _hide() {
       console.log('Hiding progress');
-      throbberView.remove();
+      throbberView.clear();
     },
   };
 });

--- a/public/stylus/spartacus.styl
+++ b/public/stylus/spartacus.styl
@@ -19,6 +19,22 @@ body, html {
     width: 100%;
 }
 
+// Add stripes when running the dev server just to make it easier to know if you're looking
+// at a webpay hosted version or the devlopment version.
+.dev-server:before {
+    background-color: yellow;
+    background-image: repeating-linear-gradient(45deg, transparent, transparent 10px, black 10px, black 20px);
+    bottom: 0;
+    content: '';
+    display: block;
+    opacity: 0.5;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 10px;
+    z-index: 20;
+}
+
 .app {
     background: $bg-color;
     grain();

--- a/server/index.js
+++ b/server/index.js
@@ -39,6 +39,17 @@ app.get('/mozpay', function (req, res) {
 app.get(/\/testlib\/?.*/, express.static(__dirname + '/../tests/static'));
 app.get(/\/unit\/?.*/, express.static(__dirname + '/../tests/'));
 
+// Fake API response.
+app.get('/mozpay/v1/api/pin/', function(req, res) {
+  var result = {
+    pin: false,
+    pin_is_locked_out: false,
+    pin_was_locked_out: false,
+    pin_locked_out: null
+  };
+  res.send(result);
+});
+
 // Fake verification.
 app.post('/fake-verify', function (req, res) {
   var assertion = req.query.assertion ? req.query.assertion : '';

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -8,11 +8,13 @@
     <link rel="stylesheet" href="/css/spartacus.css">
   </head>
   <body
+    class="dev-server"
+    data-base-api-url="{{ settings.baseApiUrl }}"
     data-privacy-policy="https://marketplace.firefox.com/privacy-policy"
+    data-reset-user-url="{{ settings.resetUserURL }}"
     data-terms-of-service="https://marketplace.firefox.com/terms-of-use"
     data-unverified-issuer="{{ settings.browseridUnverifiedIssuerl }}"
     data-verify-url="{{ settings.verifyUserURL }}"
-    data-reset-user-url="{{ settings.resetUserURL }}"
     >
     <div id="app" class="app"></div>
     <div id="progress" class="progress"></div>

--- a/tests/ui/test-login-locked.js
+++ b/tests/ui/test-login-locked.js
@@ -1,0 +1,27 @@
+var helpers = require('../helpers');
+
+helpers.startCasper('/mozpay', function(){
+  helpers.injectSinon();
+  helpers.fakeVerificationSuccess();
+  helpers.fakePinData({pin: true, pin_is_locked_out: true});
+});
+
+casper.test.begin('Login then locked', {
+  test: function(test) {
+
+    casper.waitForUrl('/mozpay/login', function() {
+      helpers.logInAsNewUser();
+    });
+
+    casper.waitForUrl('/mozpay/locked', function() {
+      test.assertSelectorHasText('h1', 'Error');
+      test.assertVisible('.full-error');
+      test.assertSelectorHasText('.msg', 'You entered the wrong pin too many times. Your account is locked. Please try your purchase again in 5 minutes.');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+
+  },
+});

--- a/tests/ui/test-login-no-pin.js
+++ b/tests/ui/test-login-no-pin.js
@@ -1,8 +1,13 @@
 var helpers = require('../helpers');
 
-helpers.startCasper('/mozpay');
+helpers.startCasper('/mozpay', function(){
+  helpers.injectSinon();
+  helpers.fakeVerificationSuccess();
+  helpers.fakePinData({pin: false});
+});
 
-casper.test.begin('Login test', {
+
+casper.test.begin('Login test no pin', {
 
   test: function(test) {
 
@@ -10,7 +15,7 @@ casper.test.begin('Login test', {
       helpers.logInAsNewUser();
     });
 
-    casper.waitForUrl('/mozpay/enter-pin', function() {
+    casper.waitForUrl('/mozpay/create-pin', function() {
       test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
     });
 

--- a/tests/ui/test-login-was-locked.js
+++ b/tests/ui/test-login-was-locked.js
@@ -1,0 +1,25 @@
+var helpers = require('../helpers');
+
+helpers.startCasper('/mozpay', function(){
+  helpers.injectSinon();
+  helpers.fakeVerificationSuccess();
+  helpers.fakePinData({pin: true, pin_was_locked_out: true});
+});
+
+casper.test.begin('Login then was-locked', {
+  test: function(test) {
+
+    casper.waitForUrl('/mozpay/login', function() {
+      helpers.logInAsNewUser();
+    });
+
+    casper.waitForUrl('/mozpay/was-locked', function() {
+      test.assertSelectorHasText('h1', 'Your Pin was locked');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+
+  },
+});

--- a/tests/ui/test-login-with-pin.js
+++ b/tests/ui/test-login-with-pin.js
@@ -1,0 +1,25 @@
+var helpers = require('../helpers');
+
+
+helpers.startCasper('/mozpay', function(){
+  helpers.injectSinon();
+  helpers.fakeVerificationSuccess();
+  helpers.fakePinData({pin: true});
+});
+
+casper.test.begin('Login test has pin', {
+  test: function(test) {
+
+    casper.waitForUrl('/mozpay/login', function() {
+      helpers.logInAsNewUser();
+    });
+
+    casper.waitForUrl('/mozpay/enter-pin', function() {
+      test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});


### PR DESCRIPTION
This adds the API check for pin state and the mocks the same for the casper tests to validate the routing is working as expected.

I've also fixed some nits with how the login checks affect routing such that this should stop the need to force render the views.

Casper has some new helpers that inject sinon so that the API responses can be mocked and tweaked to create specific states.

Oh and there's some styles for telling apart the dev/test server run instance and the webpay hosted version (just for my sanity as I'm needing to run both side-by-side as I flesh this out).
