### PR TITLE
Fix cancel from locked + tests (bug 963640)

### DIFF
--- a/public/js/lib/cancel.js
+++ b/public/js/lib/cancel.js
@@ -8,26 +8,31 @@ define([
 
   var console = log('cancel');
 
-  var callPayFailure = function callPayFailure() {
+  var pollPaymentFailed = function pollPaymentFailed() {
     // Bug 872987 introduced the injection of the "paymentSuccess" and
     // "paymentFailed" functions within a "mozPaymentProvider" object
     // instead of injecting them in the global scope. So we need to support
     // both APIs.
     var mozPayProvider = window.mozPaymentProvider || {};
     var paymentFailed = mozPayProvider.paymentFailed || window.paymentFailed;
+
     // After Bug 843309 landed, there should not be any delay before the
     // mozPaymentProvider API is injected into scope, but we keep the
     // polling loop as a safe guard.
-    throbber.show(i18n.gettext('Payment Cancelled'));
-
     if (typeof paymentFailed === 'undefined') {
       console.log('waiting for paymentFailed to appear in scope');
-      window.setTimeout(callPayFailure, 500);
+      window.setTimeout(pollPaymentFailed, 500);
     } else {
       console.log('payment failed, closing window');
       paymentFailed('USER_CANCELLED');
     }
   };
+
+
+  function callPayFailure() {
+    throbber.show(i18n.gettext('Payment Cancelled'));
+    pollPaymentFailed();
+  }
 
   return {
     callPayFailure: callPayFailure

--- a/tests/ui/test-enter-pin-400-locked.js
+++ b/tests/ui/test-enter-pin-400-locked.js
@@ -24,6 +24,15 @@ casper.test.begin('Login Enter Pin API call returns locked screen when API says 
     casper.waitForUrl('/mozpay/locked', function() {
       test.assertVisible('.locked');
       helpers.assertErrorCode('PIN_LOCKED');
+
+      // Should only be a single cancel button here.
+      test.assertElementCount('.button', 1);
+      casper.click('.button');
+    });
+
+    casper.waitUntilVisible('.throbber', function() {
+      // Check payment cancelled throbber is displayed.
+      test.assertSelectorHasText('.msg', 'Payment Cancelled');
     });
 
     casper.run(function() {


### PR DESCRIPTION
Added some tests to cover clicking cancel to close the payment flow. 

This exposed that the timeout was calling render as well as checking paymentFailed. Moving the render call outside the timeout that waits for paymentFailed to be injected fixed that.
