### PR TITLE
Update logger to report lines

### DIFF
--- a/tests/static/testlib/bind-poly.js
+++ b/tests/static/testlib/bind-poly.js
@@ -1,25 +1,6 @@
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
-if (!Function.prototype.bind) {
-  console.log('Poly-filling Function.prototype.bind');
-  Function.prototype.bind = function (oThis) {
-    if (typeof this !== "function") {
-      // closest thing possible to the ECMAScript 5 internal IsCallable function
-      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-    }
-
-    var aArgs = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP = function () {},
-        fBound = function () {
-          return fToBind.apply(this instanceof fNOP && oThis
-                                 ? this
-                                 : oThis,
-                               aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
-
-    fNOP.prototype = this.prototype;
-    fBound.prototype = new fNOP();
-
-    return fBound;
+Function.prototype.bind = Function.prototype.bind || function (thisp) {
+  var fn = this;
+  return function () {
+    return fn.apply(thisp, arguments);
   };
-}
+};


### PR DESCRIPTION
When debugging the reset flow the logging started to get annoying as it didn't report the files correctly. With enhancing logging it's really easy to screw-up the source of the log statement. 

This change removes what we don't use and fixes the line reporting.
