### PR TITLE
Kill events on init to prevent starting a zombie apocalypse.

### DIFF
--- a/public/js/views/base.js
+++ b/public/js/views/base.js
@@ -15,9 +15,13 @@ define([
 
   var BaseView = Backbone.View.extend({
     el: '#app',
-
     gettext: i18n.gettext,
     format: i18n.format,
+
+    initialize: function() {
+      // Unbind any current events as we create a new view.
+      $(this.el).unbind();
+    },
 
     setTitle: function setTitle(title) {
       // Update the title element in the page.


### PR DESCRIPTION
Noticed events firing on an unrelated view. Turns out we need to kill off events on init as we're re-using the same DOM node for views. 
