### PR TITLE
Don't allow the throbber to obscure the was-locked page (bug 1014202)

### DIFF
--- a/public/js/views/was-locked.js
+++ b/public/js/views/was-locked.js
@@ -8,6 +8,7 @@ define([
   var console = log('view', 'was-locked');
   var WasLockedView = BaseView.extend({
     render: function(){
+      app.throbber.clear();
       console.log('rendering view');
       this.setTitle(this.gettext('Was Locked'));
       this.renderTemplate('was-locked.html');

--- a/tests/ui/test-login-was-locked.js
+++ b/tests/ui/test-login-was-locked.js
@@ -15,6 +15,7 @@ casper.test.begin('Login then was-locked', {
 
     casper.waitForUrl(helpers.url('was-locked'), function() {
       test.assertSelectorHasText('h1', 'Your Pin was locked');
+      test.assertNotVisible('.throbber', 'Throbber should not be obscuring was-locked page.');
     });
 
     casper.run(function() {


### PR DESCRIPTION
\+ regression test.
