### PR TITLE
Focus trusted-ui to enable focus (bug 1015109)

### DIFF
--- a/public/js/lib/pin-widget.js
+++ b/public/js/lib/pin-widget.js
@@ -25,8 +25,14 @@ define([
   }
 
   function focusPin() {
-    console.log('Focusing pin');
+    // In the trusted UI we need to ensure it has
+    // focus otherwise programmatic focus doesn't work.
+    if (window.focus) {
+      console.log('Focusing window');
+      window.focus();
+    }
     updatePinUI();
+    console.log('Focusing pin');
     $pinInput.focus();
   }
 
@@ -69,6 +75,7 @@ define([
     $errorMessage.text(errorMessage);
     $errorMessage.removeClass('hidden');
     $forgotPin.addClass('hidden');
+    focusPin();
   }
 
   function hideError() {


### PR DESCRIPTION
Whilst here added focus after error message is shown so you don't need to manually focus.
