### PR TITLE
Add error codes (bug 1033433)

### DIFF
--- a/public/js/error-codes.js
+++ b/public/js/error-codes.js
@@ -1,0 +1,95 @@
+define([
+  'i18n-abide-utils',
+  'utils',
+], function(i18n, utils) {
+
+  var gettext = i18n.gettext;
+  var format = utils.format;
+
+  return {
+    BAD_BANGO_CODE: gettext('Mozilla received an invalid code from the payment provider (Bango) when processing the payment'),
+    // L10n: First argument is an example of the proper key format.
+    BAD_ICON_KEY: format(gettext('An image icon key was not an object. Correct example: {0}'), '{"64": "https://.../icon_64.png"}'),
+    BAD_JWT_ISSUER: gettext('No one has been registered for this JWT issuer.'),
+    BAD_PRICE_POINT: gettext('The price point is unknown or invalid.'),
+    BAD_REQUEST: gettext('The request to begin payment was invalid.'),
+    BAD_SIM_RESULT: gettext('The requested payment simulation result is not supported.'),
+    BANGO_ERROR: gettext('The payment provider (Bango) returned an error while processing the payment'),
+    EXPIRED_JWT: gettext('The JWT has expired.'),
+    EXT_ERROR: gettext('The external payment processor returned an error while handling the payment'),
+    INTERNAL_TIMEOUT: gettext('An internal web request timed out.'),
+    INVALID_JWT: gettext('The JWT signature is invalid or the JWT is malformed.'),
+    MISSING_JWT: gettext('The JWT signature is missing or invalid.'),
+    INVALID_JWT_OBJ: gettext('The JWT did not decode to a JSON object.'),
+    JWT_DECODE_ERR: gettext('Error decoding JWT.'),
+    LOGIN_TIMEOUT: gettext('The system timed out while trying to log in.'),
+    LOGOUT_TIMEOUT: gettext('The system timed out while trying to log out.'),
+    LOGOUT_ERROR: gettext('An error occurred whilst trying to log out.'),
+    LOGOUT_URL_MISSING: gettext('Misconfiguration Error. The logout URL is missing'),
+    // L10n: 'postback' is a term that means a URL accepting HTTP posts.
+    MALFORMED_URL: gettext('A URL is malformed. This could be a postback URL or an icon URL.'),
+    NO_ACTIVE_TRANS: gettext('The transaction ID was missing from the session when processing a payment return.'),
+    // L10n: First and second arguements are the names of keys.
+    NO_DEFAULT_LOC: format(gettext('If {0} is defined, then you must also define {1}.'), 'locales', 'defaultLocale'),
+    NO_PAY_FAILED_FUNC: format(gettext('{0} function was undefined'), 'paymentFailed'),
+    NO_PAY_SUCCESS_FUNC: format(gettext('{0} function was undefined'), 'paymentSuccess'),
+    // L10n: First argument is the name of the key, 'reason'.
+    NO_SIM_REASON: format(gettext("The requested chargeback simulation is missing the key '{0}'."), 'reason'),
+    NOTICE_ERROR: gettext('The notification service responded with an error while verifying the payment notice'),
+    NOTICE_EXCEPTION: gettext('The notification service raised an unexpected exception while verifying the payment notice'),
+    PAY_DISABLED: gettext('Payments are temporarily disabled.'),
+
+    PIN_CREATE_ERROR: gettext('An unexpected error occurred when creating your PIN.'),
+    PIN_CREATE_INVALID: gettext('The PIN data submitted was invalid.'),
+    PIN_CREATE_NO_USER: gettext('No valid user found whilst attempting to create your PIN'),
+    PIN_CREATE_PERM_DENIED: gettext('Permission denied attempting to create your PIN.'),
+    PIN_CREATE_TIMEOUT: gettext('The request timed out whilst attempting to create your PIN.'),
+
+    PIN_ENTER_ERROR: gettext('An unexpected error occurred whilst checking your PIN.'),
+    PIN_ENTER_NO_USER: gettext('No valid user found whilst checking your PIN'),
+    PIN_ENTER_TIMEOUT: gettext('The request timed out whilst trying to check your PIN'),
+    PIN_ENTER_PERM_DENIED: gettext('Permission denied attempting to check your PIN'),
+
+    PIN_RESET_ERROR: gettext('An unexpected error occurred when resetting your PIN.'),
+    PIN_RESET_INVALID: gettext('The PIN data submitted was invalid.'),
+    PIN_RESET_NO_USER: gettext('No valid user found whilst attempting to reset your PIN'),
+    PIN_RESET_PERM_DENIED: gettext('Permission denied attempting to reset your PIN.'),
+    PIN_RESET_TIMEOUT: gettext('The request timed out whilst attempting to reset your PIN.'),
+
+    PIN_STATE_TIMEOUT: gettext('The request timed out fetching data.'),
+    PIN_STATE_ERROR: gettext('An unexpected error occurred whilst fetching data.'),
+
+    REAUTH_LOGOUT_ERROR: gettext('An error occurred whilst trying to log out.'),
+    RESOURCE_MODIFIED: gettext('The resource has been modified within the timing of the previous request. The action should be performed again.'),
+
+    REVERIFY_DENIED: gettext('Permission denied re-verifying the user.'),
+    REVERIFY_FAILED: gettext('Re-verifying the user failed.'),
+    REVERIFY_TIMEOUT: gettext('The request to the server timed out during re-verification.'),
+    REVERIFY_MISSING_PROVIDER: gettext('The provider did not exist'),
+    REVERIFY_MISSING_URL: gettext('The re-verification url is not configured.'),
+
+    VERIFY_DENIED: gettext('Permission denied verifying the user.'),
+    VERIFY_FAILED: gettext('Verifying the user failed.'),
+    VERIFY_TIMEOUT: gettext('The request to the server timed out during verification.'),
+    VERIFY_MISSING_PROVIDER: gettext('The provider did not exist'),
+    VERIFY_MISSING_URL: gettext('The verification url is not configured.'),
+
+    SIM_DISABLED: gettext('Payment simulations are disabled at this time.'),
+    SIM_ONLY_KEY: gettext('This payment key can only be used to simulate purchases.'),
+    STATUS_PENDING_UNDEF: gettext('Status attrs are not configured correctly'),
+    STATUS_COMPLETE_UNDEF: gettext('Status attrs are not configured correctly'),
+    TRANS_CONFIG_FAILED: gettext('The configuration of the payment transaction failed.'),
+    TRANS_ENDED: gettext('The purchase cannot be completed because the current transaction has already ended.'),
+    TRANS_FAILED: gettext('The transaction failed. You have not been charged for this purchase.'),
+    TRANS_MISSING: gettext('No transaction ID could be found.'),
+    TRANS_TIMEOUT: gettext('The system timed out while waiting for a transaction.'),
+    UNSUPPORTED_PAY: gettext('The payment method or price point is not supported for this region or operator.'),
+    UNEXPECTED_STATE: gettext('An unexpected error occurred.'),
+    UNEXPECTED_ERROR: gettext('An unexpected error occurred.'),
+    USER_CANCELLED: gettext('The user cancelled the payment.'),
+    USER_HASH_EMPTY: gettext('Misconfiguration error. User data is missing'),
+    WAIT_URL_NOT_SET: gettext('Misconfiguration error. No wait URL has been configured.')
+  };
+
+});
+

--- a/public/js/lib/auth.js
+++ b/public/js/lib/auth.js
@@ -16,15 +16,11 @@ define([
   function showRetryError(options) {
     var errCode = options.errCode;
     var assertion = options.assertion;
-    var msg = options.msg || gettext('Something went wrong. Try again?');
     var reverify = options.reverify || false;
 
     app.error.render({
-      context: {
-        heading: gettext('Oops'),
-        errorCode: errCode,
-        msg: msg,
-      },
+      heading: gettext('Oops'),
+      errorCode: errCode,
       ctaCallback: function(e){
         e.preventDefault();
         app.error.close();
@@ -45,8 +41,7 @@ define([
 
     if (!url) {
       console.log('Error: No url. Please set one. Bailing out!');
-      app.error.render({context: {errorCode: 'MISSING_' + prefixUC + '_URL'}});
-      return;
+      return app.error.render({errorCode: prefixUC + '_MISSING_URL'});
     }
 
     console.log(prefix + 'ing assertion');
@@ -81,7 +76,7 @@ define([
         } else {
           utils.trackEvent({'action': 'persona login',
                             'label': prefix + ' Missing Provider'});
-          app.error.render({context: {errorCode: 'MISSING_PROVIDER'}});
+          return app.error.render({errorCode: 'MISSING_PROVIDER'});
         }
       } else {
         // Setting the attr will cause the listeners
@@ -95,7 +90,7 @@ define([
         console.log('login timed out');
         utils.trackEvent({'action': 'persona login',
                           'label': prefix + ' Timed Out'});
-        showRetryError({
+        return showRetryError({
           assertion: assertion,
           errCode: prefixUC + '_TIMEOUT',
           msg: gettext('This is taking longer than expected. Try again?'),
@@ -105,12 +100,12 @@ define([
         console.log('permission denied after auth');
         utils.trackEvent({'action': 'persona login',
                           'label': prefix + ' Permission Denied'});
-        app.error.render({context: {errorCode: prefixUC + '_DENIED'}});
+        return app.error.render({errorCode: prefixUC + '_DENIED'});
       } else {
         console.log('login error');
         utils.trackEvent({'action': 'persona login',
                           'label': prefix + ' Failed'});
-        showRetryError({
+        return showRetryError({
           assertion: assertion,
           errCode: prefixUC + '_FAILED',
           reverify: reverify,

--- a/public/js/lib/provider.js
+++ b/public/js/lib/provider.js
@@ -71,7 +71,7 @@ define(['jquery', 'log', 'underscore', 'utils'], function($, log, _, utils) {
     prepareAll: function(userHash) {
 
       if (!userHash) {
-        app.error.render({context: {errorCode: 'USER_HASH_EMPTY'}});
+        app.error.render({errorCode: 'USER_HASH_EMPTY'});
         return $.Deferred().reject();
       }
 
@@ -126,7 +126,7 @@ define(['jquery', 'log', 'underscore', 'utils'], function($, log, _, utils) {
       return req;
     } else {
       console.error('Bango logout url missing');
-      app.error.render({'context': {'errorCode': 'LOGOUT_URL_MISSING'}});
+      app.error.render({errorCode: 'LOGOUT_URL_MISSING'});
       return $.Deferred().reject();
     }
   };

--- a/public/js/lib/utils.js
+++ b/public/js/lib/utils.js
@@ -22,19 +22,11 @@ define([
     mozPaymentProvider: window.mozPaymentProvider || {
       paymentSuccess: window.paymentSuccess || function() {
         console.error('No paymentSuccess function');
-        app.error.render({
-          context: {
-            errorCode: 'NO_PAY_SUCCESS_FUNC',
-          },
-        });
+        return app.error.render({errorCode: 'NO_PAY_SUCCESS_FUNC'});
       },
       paymentFailed: window.paymentFailed || function() {
         console.error('No paymentFailed function');
-        app.error.render({
-          context: {
-            errorCode: 'NO_PAY_FAILED_FUNC',
-          },
-        });
+        return app.error.render({errorCode: 'NO_PAY_FAILED_FUNC'});
       },
     },
     trackClick: function() {

--- a/public/js/lib/wait.js
+++ b/public/js/lib/wait.js
@@ -46,11 +46,7 @@ define([
       utils.trackEvent({'action': 'payment',
                         'label': 'Transaction Failed to be found'});
       app.throbber.close();
-      app.error.render({
-        context: {
-          errorCode: 'TRANS_NOT_FOUND'
-        },
-      });
+      return app.error.render({errorCode: 'TRANS_NOT_FOUND'});
     }, settings.wait_timeout);
   }
 
@@ -72,13 +68,7 @@ define([
     }
 
     if (!startUrl) {
-      app.error.render({
-        context: {
-          errorCode: 'WAIT_URL_NOT_SET',
-          msg: gettext('No wait URL has been set. Aborting.')
-        },
-      });
-      return;
+      return app.error.render({errorCode: 'WAIT_URL_NOT_SET'});
     }
 
     request = $.ajax({
@@ -111,12 +101,7 @@ define([
         clear();
         app.throbber.close();
         console.log('transaction failed');
-        app.error.render({
-          context: {
-            errorCode: 'TRANS_FAILED',
-            msg: gettext('The transaction failed. You have not been charged for this purchase.')
-          },
-        });
+        return app.error.render({errorCode: 'TRANS_FAILED'});
 
       } else if (data.status === utils.bodyData.transStatusCancelled) {
         clear();
@@ -142,11 +127,9 @@ define([
         utils.trackEvent({'action': 'payment',
                           'label': 'Transaction Request Timed Out'});
         app.throbber.close();
-        app.error.render({
-          context: {
-            ctaText: gettext('Retry?'),
-            errorCode: 'TRANS_TIMEOUT'
-          },
+        return app.error.render({
+          ctaText: gettext('Retry?'),
+          errorCode: 'TRANS_TIMEOUT',
           ctaCallback: function(e){
             e.preventDefault();
             startWaiting(expectedStatus);

--- a/public/js/views/create-pin.js
+++ b/public/js/views/create-pin.js
@@ -61,11 +61,9 @@ define([
           console.log('Request timed out');
           utils.trackEvent({'action': pinCreateAction,
                             'label': 'Pin Create API Call Timed Out'});
-          app.error.render({
-            context: {
-              ctaText: that.gettext('Retry?'),
-              errorCode: 'CREATE_PIN_TIMEOUT'
-            },
+          return app.error.render({
+            ctaText: that.gettext('Retry?'),
+            errorCode: 'PIN_CREATE_TIMEOUT',
             ctaCallback: function(e){
               e.preventDefault();
               that.submitData(pinData);
@@ -76,22 +74,22 @@ define([
           console.log('Pin data invalid');
           utils.trackEvent({'action': pinCreateAction,
                             'label': 'Pin Create API Call Invalid Form Data'});
-          app.error.render({context: {errorCode: 'PIN_CREATE_INVALID'}});
+          return app.error.render({errorCode: 'PIN_CREATE_INVALID'});
         } else if ($xhr.status === 403) {
           console.log('User not authenticated');
           utils.trackEvent({'action': pinCreateAction,
                             'label': 'Pin Create API Call Permission Denied'});
-          app.error.render({context: {errorCode: 'PIN_CREATE_PERM_DENIED'}});
+          return app.error.render({errorCode: 'PIN_CREATE_PERM_DENIED'});
         } else if ($xhr.status === 404) {
           console.log("User doesn't exist");
           utils.trackEvent({'action': pinCreateAction,
                             'label': "Pin Create API Call User Doesn't exist"});
-          app.error.render({context: {errorCode: 'PIN_CREATE_USER_DOES_NOT_EXIST'}});
+          return app.error.render({errorCode: 'PIN_CREATE_NO_USER'});
         } else {
           console.log("Unhandled error");
           utils.trackEvent({'action': pinCreateAction,
                             'label': "Pin Create API Call Unhandled error"});
-          app.error.render({context: {errorCode: 'PIN_CREATE_UNHANDLED_ERROR'}});
+          return app.error.render({errorCode: 'PIN_CREATE_ERROR'});
         }
       });
       return req;

--- a/public/js/views/enter-pin.js
+++ b/public/js/views/enter-pin.js
@@ -57,11 +57,9 @@ define([
           console.log('Request timed out');
           utils.trackEvent({action: pinCheckAction,
                             label: 'Pin Check API Call Timed Out'});
-          app.error.render({
-            context: {
-              ctaText: that.gettext('Retry?'),
-              errorCode: 'ENTER_PIN_TIMEOUT'
-            },
+          return app.error.render({
+            ctaText: that.gettext('Retry?'),
+            errorCode: 'PIN_ENTER_TIMEOUT',
             ctaCallback: function(e) {
               e.preventDefault();
               that.handleSubmit();
@@ -78,17 +76,17 @@ define([
           console.log('User not authenticated');
           utils.trackEvent({action: pinCheckAction,
                             label: 'Pin Check API Call Permission Denied'});
-          app.error.render({context: {errorCode: 'PIN_ENTER_PERM_DENIED'}});
+          return app.error.render({errorCode: 'PIN_ENTER_PERM_DENIED'});
         } else if ($xhr.status === 404) {
           console.log("User doesn't exist");
           utils.trackEvent({action: pinCheckAction,
                             label: "Pin Check API Call User Doesn't exist"});
-          app.error.render({context: {errorCode: 'PIN_ENTER_USER_DOES_NOT_EXIST'}});
+          return app.error.render({errorCode: 'PIN_ENTER_NO_USER'});
         } else {
           console.log("Unhandled error");
           utils.trackEvent({action: pinCheckAction,
                             label: 'Pin Check API Call Unhandled error'});
-          app.error.render({context: {errorCode: 'PIN_ENTER_UNHANDLED_ERROR'}});
+          return app.error.render({errorCode: 'PIN_ENTER_ERROR'});
         }
       });
     },

--- a/public/js/views/error.js
+++ b/public/js/views/error.js
@@ -2,9 +2,10 @@
 // That sits in it's own container.
 define([
   'cancel',
+  'error-codes',
   'log',
   'views/base'
-], function(cancel, log, BaseView){
+], function(cancel, errorCodes, log, BaseView){
 
   'use strict';
 
@@ -25,25 +26,43 @@ define([
     },
 
     render: function(options){
-      this.close();
       options = options || {};
+
+      this.close();
       this.$el.empty();
       this.delegateEvents(this.events);
 
       if (window.app && app.throbber) {
         app.throbber.close();
       }
-      var context = options.context || {};
+
+      var errorCode = options.errorCode;
+      var msg = options.msg;
       var template = options.template || 'error.html';
 
-      // Default to showing the cancel button.
-      context.showCancel = options.showCancel === false ? false : true;
-      // Default to showing not the call to action button.
-      context.showCta = options.showCta || false;
+      if (!msg && errorCode) {
+        msg = errorCodes[errorCode];
+      }
 
-      // Add default heading + msg.
-      context.heading = context.heading || this.gettext('Error');
-      context.msg = context.msg || this.gettext('Something went wrong.');
+      var context = {
+        // The call to action button text.
+        ctaText: options.ctaText,
+        // The cancelText for the cancel button.
+        cancelText: options.cancelText,
+        // The error code to display.
+        errorCode: errorCode,
+        // Add default heading + msg.
+        heading: options.heading || this.gettext('Error'),
+        // Use passed-in msg / or errorCode message / or default.
+        msg: msg || this.gettext('Something went wrong.'),
+        // The page class for the error message.
+        pageclass: options.pageclass,
+        // Default to showing the cancel button.
+        showCancel: options.showCancel === false ? false : true,
+        // Default to showing not the call to action button.
+        showCta: options.showCta || false,
+      };
+
       console.log(JSON.stringify(context));
 
       this.setTitle(context.heading);
@@ -68,7 +87,6 @@ define([
       // Make it so!
       console.log('Rendering Error template');
       this.renderTemplate(template, context);
-      return this;
     }
 
   });

--- a/public/js/views/force-auth.js
+++ b/public/js/views/force-auth.js
@@ -43,11 +43,9 @@ define([
         window.clearTimeout(this.forceAuthTimer);
       }
 
-      app.error.render({
-        context: {
-          ctaText: that.gettext('Retry?'),
-          errorCode: 'REAUTH_LOGIN_TIMEOUT'
-        },
+      return app.error.render({
+        ctaText: that.gettext('Retry?'),
+        errorCode: 'REAUTH_LOGIN_TIMEOUT',
         ctaCallback: function(e) {
           e.preventDefault();
           that.forceReAuthentication();

--- a/public/js/views/init.js
+++ b/public/js/views/init.js
@@ -27,7 +27,7 @@ define([
       } else {
         utils.trackEvent({action: 'extract jwt before login',
                           label: 'Invalid or missing JWT'});
-        app.error.render({context: {'errorCode': 'INVALID_JWT'}});
+        return app.error.render({'errorCode': 'MISSING_JWT'});
       }
     }
 

--- a/public/js/views/locked.js
+++ b/public/js/views/locked.js
@@ -17,13 +17,11 @@ define([
 
       // The locked view is just a specialized error message.
       app.error.render({
-        context: {
-          pageclass: 'full-error locked',
-          heading: this.gettext('Error'),
-          msg: this.gettext('You entered the wrong PIN too many times. Your account is locked. Please try your purchase again in 5 minutes.'),
-          errorCode: 'PIN_LOCKED',
-          cancelText: this.gettext('OK')
-        }
+        pageclass: 'full-error locked',
+        heading: this.gettext('Error'),
+        msg: this.gettext('You entered the wrong PIN too many times. Your account is locked. Please try your purchase again in 5 minutes.'),
+        errorCode: 'PIN_LOCKED',
+        cancelText: this.gettext('OK')
       });
 
       return this;

--- a/public/js/views/page.js
+++ b/public/js/views/page.js
@@ -71,8 +71,7 @@ define([
       } else {
         utils.trackEvent({action: 'login state change',
                           label: 'Unexpected change value'});
-        app.error.render({'context': {'errorCode': 'UNEXPECTED_LOGIN_STATE'}});
-        return;
+        return app.error.render({errorCode: 'UNEXPECTED_LOGIN_STATE'});
       }
     },
 
@@ -107,7 +106,6 @@ define([
           console.log('Transaction started successfully');
           utils.trackEvent({action: 'start-transaction',
                             label: 'Transaction started successfully'});
-
           var providerName = data.provider;
           if (settings.validProviders.indexOf(providerName) > -1) {
             app.transaction.set('provider', providerName);
@@ -117,18 +115,18 @@ define([
                 if (textStatus === 'timeout') {
                   utils.trackEvent({action: 'fetch-state',
                                     label: 'Fetching initial state timed-out.'});
-                  app.error.render({'context': {'errorCode': 'PIN_STATE_TIMEOUT'},
-                                    ctaCallback: that.setUpPayment});
+                  return app.error.render({errorCode: 'PIN_STATE_TIMEOUT',
+                                           ctaCallback: that.setUpPayment});
                 } else {
                   utils.trackEvent({action: 'fetch-state',
                                     label: 'Fetching initial state error.'});
-                  app.error.render({'context': {'errorCode': 'PIN_STATE_ERROR'}});
+                  return app.error.render({errorCode: 'PIN_STATE_ERROR'});
                 }
               });
               return req;
             });
           } else {
-            app.error.render({'context': {'errorCode': 'UNEXPECTED_PROVIDER'}});
+            return app.error.render({'errorCode': 'UNEXPECTED_PROVIDER'});
           }
         }).fail(function($xhr, textStatus) {
           console.log($xhr.status);
@@ -136,18 +134,18 @@ define([
           if (textStatus === 'timeout') {
             utils.trackEvent({action: 'start-transaction',
                               label: 'Transaction start timed-out'});
-            app.error.render({'context': {'errorCode': 'START_TRANS_TIMEOUT'},
-                              ctaCallback: function(){ that.setUpPayment(); } });
+            return app.error.render({errorCode: 'TRANS_TIMEOUT',
+                                     ctaCallback: function(){ that.setUpPayment(); }});
           } else {
             utils.trackEvent({action: 'start-transaction',
                               label: 'Transaction failed to start'});
-            app.error.render({'context': {'errorCode': 'START_TRANS_FAILURE'}});
+            return app.error.render({errorCode: 'TRANS_CONFIG_FAILED'});
           }
         });
       } else {
         utils.trackEvent({action: 'start-transaction',
                           label: 'Invalid or missing JWT'});
-        app.error.render({context: {'errorCode': 'INVALID_JWT'}});
+        return app.error.render({errorCode: 'MISSING_JWT'});
       }
     },
 

--- a/public/js/views/reset-pin.js
+++ b/public/js/views/reset-pin.js
@@ -25,11 +25,9 @@ define([
           console.log('Request timed out');
           utils.trackEvent({'action': pinResetAction,
                             'label': 'Pin Reset API Call Timed Out'});
-          app.error.render({
-            context: {
-              ctaText: that.gettext('Retry?'),
-              errorCode: 'PIN_RESET_TIMEOUT'
-            },
+          return app.error.render({
+            ctaText: that.gettext('Retry?'),
+            errorCode: 'PIN_RESET_TIMEOUT',
             ctaCallback: function(e){
               e.preventDefault();
               that.submitData(pinData);
@@ -39,17 +37,22 @@ define([
           console.log('Pin data invalid');
           utils.trackEvent({'action': pinResetAction,
                             'label': 'Pin Reset API Call Invalid Form Data'});
-          app.error.render({context: {errorCode: 'PIN_RESET_INVALID'}});
+          return app.error.render({errorCode: 'PIN_RESET_INVALID'});
         } else if ($xhr.status === 403) {
           console.log('User not authenticated');
           utils.trackEvent({'action': pinResetAction,
                             'label': 'Pin Reset API Call Permission Denied'});
-          app.error.render({context: {errorCode: 'PIN_RESET_PERM_DENIED'}});
+          return app.error.render({errorCode: 'PIN_RESET_PERM_DENIED'});
+        } else if ($xhr.status === 404) {
+          console.log('User not authenticated');
+          utils.trackEvent({'action': pinResetAction,
+                            'label': "Pin Reset API Call User doesn't exist"});
+          return app.error.render({errorCode: 'PIN_RESET_NO_USER'});
         } else {
           console.log("Unhandled error");
           utils.trackEvent({'action': pinResetAction,
                             'label': "Pin Reset API Call Unhandled error"});
-          app.error.render({context: {errorCode: 'PIN_RESET_ERROR'}});
+          return app.error.render({errorCode: 'PIN_RESET_ERROR'});
         }
         return req;
       });

--- a/public/js/views/reset-start.js
+++ b/public/js/views/reset-start.js
@@ -76,8 +76,7 @@ define([
       } else {
         utils.trackEvent({'action': 'forgot pin',
                             'label': 'Missing Provider'});
-        app.error.render({context: {errorCode: 'MISSING_PROVIDER'}});
-        return;
+        return app.error.render({errorCode: 'MISSING_PROVIDER'});
       }
 
       var authResetUser = auth.resetUser();
@@ -114,11 +113,9 @@ define([
           utils.trackEvent({'action': 'forgot pin',
                             'label': 'Logout Error'});
           // This can be a timeout or a failure. So a more generic message is needed.
-          app.error.render({
-            context: {
-              ctaText: that.gettext('Retry?'),
-              errorCode: 'LOGOUT_ERROR'
-            },
+          return app.error.render({
+            ctaText: that.gettext('Retry?'),
+            errorCode: 'LOGOUT_ERROR',
             ctaCallback: function(e) {
               that.handleResetStart(e);
             }

--- a/public/js/views/wait-to-finish.js
+++ b/public/js/views/wait-to-finish.js
@@ -16,11 +16,7 @@ define([
       if (typeof statusCompleted !== 'undefined') {
         wait.startWaiting(statusCompleted);
       } else {
-        return app.error.render({
-          context: {
-            errorCode: 'STATUS_COMPLETE_UNDEF',
-          },
-        });
+        return app.error.render({errorCode: 'STATUS_COMPLETE_UNDEF'});
       }
       return this;
     }

--- a/public/js/views/wait-to-start.js
+++ b/public/js/views/wait-to-start.js
@@ -17,11 +17,7 @@ define([
       if (typeof statusPending !== 'undefined') {
         wait.startWaiting(statusPending);
       } else {
-        return app.error.render({
-          context: {
-            errorCode: 'STATUS_PENDING_UNDEF',
-          },
-        });
+        return app.error.render({errorCode: 'STATUS_PENDING_UNDEF'});
       }
       return this;
     }

--- a/public/js/views/was-locked.js
+++ b/public/js/views/was-locked.js
@@ -23,7 +23,7 @@ define([
       } else {
         utils.trackEvent({action: 'was-locked',
                           label: 'Unexpected state'});
-        app.error.render({'context': {'errorCode': 'UNEXPECTED_STATE'}});
+        return app.error.render({'errorCode': 'UNEXPECTED_STATE'});
       }
     },
 

--- a/templates/error.html
+++ b/templates/error.html
@@ -7,7 +7,7 @@
   <section class="content error">
     <div class="msg">
       <h1>{{ heading }}</h1>
-      <p>{{ msg }}</p>
+      <p class="message">{{ msg }}</p>
       {% if errorCode %}<p class="error-code">{{ errorCode }}</p>{% endif %}
     </div>
   </section>

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -183,8 +183,8 @@ function injectSinon(options) {
             request.respond(response[0], response[1], response[2]);
           }
         } catch (e) {
-          console.log(i);
           console.log('Sinon exception error', e);
+          throw e;
         }
       };
     }

--- a/tests/static/testlib/testrunner.js
+++ b/tests/static/testlib/testrunner.js
@@ -4,6 +4,7 @@ require(['/js/require-config.js'], function() {
 
   require([
     '/unit/test-base-view.js',
+    '/unit/test-error-codes.js',
     '/unit/test-errors.js',
     '/unit/test-locale-utils.js',
     '/unit/test-mcc-mnc.js',

--- a/tests/ui/test-create-pin-404.js
+++ b/tests/ui/test-create-pin-404.js
@@ -27,7 +27,7 @@ casper.test.begin('Create pin returns 404 (no user)', {
 
     casper.waitUntilVisible('.full-error', function() {
       test.assertVisible('.full-error', 'Error page should be shown');
-      helpers.assertErrorCode('PIN_CREATE_USER_DOES_NOT_EXIST');
+      helpers.assertErrorCode('PIN_CREATE_NO_USER');
       test.assertElementCount('.full-error .button', 1, 'Should only be one button for cancelling the flow');
       casper.click('.full-error .button');
     });

--- a/tests/ui/test-create-pin-timeout.js
+++ b/tests/ui/test-create-pin-timeout.js
@@ -26,7 +26,7 @@ casper.test.begin('Create pin timeout then success.', {
     });
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('CREATE_PIN_TIMEOUT');
+      helpers.assertErrorCode('PIN_CREATE_TIMEOUT');
       test.assertVisible('.button.cta', 'CTA buttons should be visible');
       test.assertVisible('.button.cancel', 'Cancel button should be visible');
       helpers.fakePinData({data: {pin: true}, method: 'POST', statusCode: 204});

--- a/tests/ui/test-enter-pin-404.js
+++ b/tests/ui/test-enter-pin-404.js
@@ -23,7 +23,7 @@ casper.test.begin('Login Enter Pin API call returns 404', {
 
     casper.waitUntilVisible('.full-error', function() {
       test.assertVisible('.full-error', 'Error page should be shown');
-      helpers.assertErrorCode('PIN_ENTER_USER_DOES_NOT_EXIST');
+      helpers.assertErrorCode('PIN_ENTER_NO_USER');
       test.assertElementCount('.full-error .button', 1, 'Should only be one button for cancelling the flow');
       casper.click('.full-error .button');
     });

--- a/tests/ui/test-enter-pin-timeout.js
+++ b/tests/ui/test-enter-pin-timeout.js
@@ -22,7 +22,7 @@ casper.test.begin('Enter pin timeout then success', {
     });
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('ENTER_PIN_TIMEOUT');
+      helpers.assertErrorCode('PIN_ENTER_TIMEOUT');
       test.assertVisible('.button.cta', 'CTA buttons should be visible');
       test.assertVisible('.button.cancel', 'Cancel button should be visible');
       helpers.fakePinData({data: {pin: true}, method: 'POST', statusCode: 200, url:'/mozpay/v1/api/pin/check/'});

--- a/tests/ui/test-invalid-jwt.js
+++ b/tests/ui/test-invalid-jwt.js
@@ -8,7 +8,7 @@ casper.test.begin('Check invalid JWT', {
   test: function(test) {
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('INVALID_JWT');
+      helpers.assertErrorCode('MISSING_JWT');
     });
 
     casper.run(function() {

--- a/tests/ui/test-invalid-start.js
+++ b/tests/ui/test-invalid-start.js
@@ -8,7 +8,7 @@ casper.test.begin('Check non-mozpay url to start.', {
   test: function(test) {
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('INVALID_JWT');
+      helpers.assertErrorCode('MISSING_JWT');
     });
 
     casper.run(function() {

--- a/tests/ui/test-start-transaction-failure.js
+++ b/tests/ui/test-start-transaction-failure.js
@@ -14,7 +14,7 @@ casper.test.begin('Transaction failure should only have cancel option.', {
     helpers.doLogin();
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('START_TRANS_FAILURE');
+      helpers.assertErrorCode('TRANS_CONFIG_FAILED');
       test.assertVisible('.full-error .button', 'Cancel button should be visible');
       test.assertElementCount('.full-error .button', 1, 'Should only be one button for cancelling the flow');
       casper.click('.full-error .button');

--- a/tests/ui/test-start-transaction-timeout.js
+++ b/tests/ui/test-start-transaction-timeout.js
@@ -14,7 +14,7 @@ casper.test.begin('Start transaction timout, retry then success.', {
     helpers.doLogin();
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('START_TRANS_TIMEOUT');
+      helpers.assertErrorCode('TRANS_TIMEOUT');
       test.assertVisible('.button.cta', 'CTA button should be visible');
       test.assertVisible('.button.cancel', 'Cancel button should be visible');
 

--- a/tests/unit/test-error-codes.js
+++ b/tests/unit/test-error-codes.js
@@ -1,0 +1,20 @@
+define(['error-codes'], function(errorCodes) {
+
+  var assert = chai.assert;
+
+  suite('Test error code lookup', function(){
+
+    test('Check format in error code string', function(){
+      assert.include(errorCodes.BAD_ICON_KEY, 'icon_64.png');
+    });
+
+    test('Check ordered format in error code string', function(){
+      var noDefaultLoc = errorCodes.NO_DEFAULT_LOC;
+      assert.include(noDefaultLoc, 'locales');
+      assert.include(noDefaultLoc, 'defaultLocale');
+      assert.ok(noDefaultLoc.indexOf('locale') < noDefaultLoc.indexOf('defaultLocale'));
+    });
+
+  });
+
+});

--- a/tests/unit/test-errors.js
+++ b/tests/unit/test-errors.js
@@ -28,26 +28,33 @@ define(['jquery', 'views/error'], function($, ErrorView) {
 
     test('Check error overlay page class is set', function(){
       assert.ok($('#error .full-error').length === 0);
-      this.error.render({context: {'pageclass': 'full-error whatevs'}});
+      this.error.render({'pageclass': 'full-error whatevs'});
       assert.ok($('#error .page').hasClass('whatevs'));
     });
 
     test('Check error overlay heading is set', function(){
       assert.ok($('#error .full-error').length === 0);
-      this.error.render({context: {'heading': 'wassup'}});
-      assert.ok($('#error .full-error h1').text('wassap'));
+      this.error.render({'heading': 'wassup'});
+      assert.equal($('#error .full-error h1').text(), 'wassup');
     });
 
     test('Check error overlay msg is set', function(){
       assert.ok($('#error .full-error').length === 0);
-      this.error.render({context: {'msg': 'woops'}});
-      assert.ok($('#error .full-error .msg').text('woops'));
+      this.error.render({'msg': 'woops'});
+      assert.equal($('#error .full-error .message').text(), 'woops');
     });
 
     test('Check error overlay msg escaping', function(){
       assert.ok($('#error .full-error').length === 0);
-      this.error.render({context: {'msg': '<b>woops</b>'}});
-      assert.ok($('#error .full-error .msg').text('&lt;b&gt;woops&lt;/b&gt;'));
+      this.error.render({'msg': '<b>woops</b>'});
+      assert.include($('#error .full-error .msg').html(), '&lt;b&gt;woops&lt;/b&gt;');
+    });
+
+    test('Check render errorCode', function(){
+      assert.ok($('#error .full-error').length === 0);
+      this.error.render({errorCode: 'MISSING_JWT'});
+      assert.equal($('#error .full-error .message').text(), 'The JWT signature is missing or invalid.');
+      assert.equal($('#error .full-error .error-code').text(), 'MISSING_JWT');
     });
 
   });


### PR DESCRIPTION
To be able to show an error page that displays an error based on an error code we need the webpay/base/dev_messages.py equivalent in Spartacus.

In addition this cleans up the error messages makes sure they're used consistently and always return.
I've simplified the render api a little bit more too so you don't need a context object just to pass an `errorCode`. 
