### PR TITLE
Defer payment provider logout (bug 1037513)

### DIFF
--- a/public/js/lib/auth.js
+++ b/public/js/lib/auth.js
@@ -4,9 +4,8 @@ define([
   'id',
   'jquery',
   'log',
-  'provider',
   'utils',
-], function(cancel, i18n, id, $, log, provider, utils) {
+], function(cancel, i18n, id, $, log, utils) {
 
   'use strict';
 
@@ -64,20 +63,7 @@ define([
         // Set logged_in and manually direct to reset-pin which is
         // implied having successfully carried out a re-auth.
         app.session.set('logged_in', true, {silent: true});
-        // provider (boku/bango/reference) was set when transaction was created.
-        // Therefore we should just be able to get it and use
-        // it to run the provider preparation ahead of the reset.
-        var providerName = app.transaction.get('provider');
-        if (providerName) {
-          var Provider = provider.providerFactory(providerName);
-          Provider.prepareAll(data.user_hash).done(function() {
-            app.router.navigate('spa/reset-pin', {trigger: true});
-          });
-        } else {
-          utils.trackEvent({'action': 'persona login',
-                            'label': prefix + ' Missing Provider'});
-          return app.error.render({errorCode: 'MISSING_PROVIDER'});
-        }
+        app.router.navigate('spa/reset-pin', {trigger: true});
       } else {
         // Setting the attr will cause the listeners
         // to deal with login success.

--- a/public/js/lib/provider.js
+++ b/public/js/lib/provider.js
@@ -78,8 +78,11 @@ define(['jquery', 'log', 'underscore', 'utils'], function($, log, _, utils) {
       var existingUser = this.storage.getItem('spa-user-hash');
       this.storage.setItem('spa-user-hash', userHash);
 
+      console.log('new user hash =', userHash,
+                  'existing user hash =', existingUser);
+
       if (existingUser && existingUser !== userHash) {
-        console.log('logout: new user hash', userHash, '!== saved hash', existingUser);
+        console.log('User has changed: do logout');
         utils.trackEvent({'action': 'user change detection',
                           'label': 'User Changed'});
         return this.logout();
@@ -105,8 +108,8 @@ define(['jquery', 'log', 'underscore', 'utils'], function($, log, _, utils) {
   Bango.prototype.logout = function() {
 
     // Log out of Bango so that cookies are cleared.
-    console.log('Logging out of Bango');
     var url = utils.bodyData.bangoLogoutUrl;
+    console.log('Logging out of Bango at', url);
     if (url) {
       var req = $.ajax({url: url, dataType: 'script'});
 

--- a/public/js/views/reset-start.js
+++ b/public/js/views/reset-start.js
@@ -15,12 +15,11 @@ define([
   'id',
   'jquery',
   'log',
-  'provider',
   'settings',
   'underscore',
   'utils',
   'views/page',
-], function(auth, cancel, id, $, log, provider, settings, _, utils, PageView){
+], function(auth, cancel, id, $, log, settings, _, utils, PageView){
 
   'use strict';
 
@@ -69,18 +68,7 @@ define([
 
       app.throbber.render(this.gettext('Connecting to Persona'));
 
-      var providerInst;
-      var providerName = app.transaction.get('provider');
-      if (providerName) {
-        providerInst = provider.providerFactory(providerName);
-      } else {
-        utils.trackEvent({'action': 'forgot pin',
-                            'label': 'Missing Provider'});
-        return app.error.render({errorCode: 'MISSING_PROVIDER'});
-      }
-
       var authResetUser = auth.resetUser();
-      var providerLogout = providerInst.logout();
       var personaLogout = this.logoutPersona();
 
       if (this.resetLogoutTimeout) {
@@ -92,11 +80,10 @@ define([
         // If the log-out times-out then abort/reject the requests/deferred.
         console.log('logout timed-out');
         authResetUser.abort();
-        providerLogout.abort();
         personaLogout.reject();
       }, settings.logout_timeout);
 
-      $.when(authResetUser, providerLogout, personaLogout)
+      $.when(authResetUser, personaLogout)
         .done(function _allLoggedOut() {
           console.log('Clearing logout reset timer.');
           window.clearTimeout(that.resetLogoutTimeout);

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -16,6 +16,7 @@
     data-unverified-issuer="{{ settings.browseridUnverifiedIssuerl }}"
     data-verify-url="{{ settings.verifyUserURL }}"
     data-reverify-url="{{ settings.reVerifyUserURL }}"
+    data-bango-logout-url="/fake/bango/logout/"
     data-static-docs-url="{{ settings.staticURL }}"
     {% if transaction_status_url -%}
       data-trans-start-url="{{ transaction_status_url }}"

--- a/tests/ui/test-wait-to-start-missing-provider.js
+++ b/tests/ui/test-wait-to-start-missing-provider.js
@@ -1,0 +1,50 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  sinon: {
+    // Process respondWith calls in order.
+    consumeStack: true
+  },
+  setUp: function(){
+    helpers.fakeLogout();
+    helpers.fakeVerification({userHash: 'new-user'});
+    helpers.fakeStartTransaction();
+    helpers.fakePinData({data: {pin: true}});
+    helpers.fakePinData({data: {pin: true},
+                         method: 'POST',
+                         statusCode: 200,
+                         url: '/mozpay/v1/api/pin/check/'});
+    helpers.fakeWaitPoll({type: 'start',
+                          provider: null});  // empty provider.
+    helpers.fakeProviderLogout();
+  },
+});
+
+casper.test.begin('Test wait to start polling failed status.', {
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('enter-pin'), function() {
+      test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+      this.sendKeys('.pinbox', '1234');
+      test.assertExists('.cta:enabled', 'Submit button is enabled');
+
+      casper.evaluate(function() {
+        // Simulate how an old user would already be logged in.
+        // This forces a provider logout.
+        localStorage.setItem('spa-user-hash', 'old-user');
+      });
+
+      this.click('.cta');
+    });
+
+    casper.waitForSelector('.full-error', function() {
+      helpers.assertErrorCode('MISSING_PROVIDER');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});

--- a/tests/ui/test-wait-to-start-provider-fail.js
+++ b/tests/ui/test-wait-to-start-provider-fail.js
@@ -1,0 +1,49 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  sinon: {
+    // Process respondWith calls in order.
+    consumeStack: true
+  },
+  setUp: function(){
+    helpers.fakeLogout();
+    helpers.fakeVerification({userHash: 'new-user'});
+    helpers.fakeStartTransaction();
+    helpers.fakePinData({data: {pin: true}});
+    helpers.fakePinData({data: {pin: true},
+                         method: 'POST',
+                         statusCode: 200,
+                         url: '/mozpay/v1/api/pin/check/'});
+    helpers.fakeWaitPoll({type: 'start'});  // transaction is ready.
+    helpers.fakeProviderLogout({statusCode: 500});
+  },
+});
+
+casper.test.begin('Test wait to start polling failed status.', {
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('enter-pin'), function() {
+      test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+      this.sendKeys('.pinbox', '1234');
+      test.assertExists('.cta:enabled', 'Submit button is enabled');
+
+      casper.evaluate(function() {
+        // Simulate how an old user would already be logged in.
+        // This forces a provider logout.
+        localStorage.setItem('spa-user-hash', 'old-user');
+      });
+
+      this.click('.cta');
+    });
+
+    casper.waitForSelector('.full-error', function() {
+      helpers.assertErrorCode('PROVIDER_LOGOUT_FAIL');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});

--- a/tests/ui/test-wait-to-start-provider-logout.js
+++ b/tests/ui/test-wait-to-start-provider-logout.js
@@ -1,0 +1,51 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  sinon: {
+    // Process respondWith calls in order.
+    consumeStack: true
+  },
+  setUp: function(){
+    helpers.fakeLogout();
+    helpers.fakeVerification({userHash: 'new-user'});
+    helpers.fakeStartTransaction();
+    helpers.fakePinData({data: {pin: true}});
+    helpers.fakePinData({data: {pin: true},
+                         method: 'POST',
+                         statusCode: 200,
+                         url: '/mozpay/v1/api/pin/check/'});
+    helpers.fakeWaitPoll({type: 'start'});  // transaction is ready.
+    helpers.fakeProviderLogout();
+  },
+});
+
+casper.test.begin('Test wait to start polling', {
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('enter-pin'), function() {
+      test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+      this.sendKeys('.pinbox', '1234');
+      test.assertExists('.cta:enabled', 'Submit button is enabled');
+
+      casper.evaluate(function() {
+        // Simulate how an old user would already be logged in.
+        // This forces a provider logout.
+        localStorage.setItem('spa-user-hash', 'old-user');
+      });
+
+      this.click('.cta');
+    });
+
+    casper.waitForUrl('/fake-provider', function() {
+      // This is just a check to make sure we are redirected correctly to the
+      // provided url when the transaction state changes to pending.
+      casper.echo('FAKE PROVIDER');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});


### PR DESCRIPTION
The API to start a transaction doesn't return
a payment provider because the transaction has not
been created yet. This defers payment provider logout
until right before we redirect to the provider's web
flow.

@muffinresearch r?

There is also a Webpay patch coming shortly.
