### PR TITLE
Remove useless message

### DIFF
--- a/public/js/lib/provider.js
+++ b/public/js/lib/provider.js
@@ -71,7 +71,6 @@ define(['jquery', 'log', 'underscore', 'utils'], function($, log, _, utils) {
     prepareAll: function(userHash) {
 
       if (!userHash) {
-        app.error.render({errorCode: 'USER_HASH_EMPTY'});
         return $.Deferred().reject();
       }
 


### PR DESCRIPTION
This message is pretty useless as it won't be seen as the failure handlers that are called when the deferred is rejected renders an error anyway.
