### PR TITLE
preserve localStorage for SIM logout (bug 1042381)

### DIFF
--- a/public/js/lib/auth.js
+++ b/public/js/lib/auth.js
@@ -166,7 +166,6 @@ define([
     var req = $.ajax(reqConfig);
     req.done(function _resetSuccess() {
       console.log('reset webpay user');
-      window.localStorage.clear();
       utils.trackEvent({'action': 'webpay user reset',
                         'label': 'Reset User Success'});
     }).fail(function _resetFail($xhr, textStatus, errorThrown) {

--- a/public/js/lib/provider.js
+++ b/public/js/lib/provider.js
@@ -34,16 +34,18 @@ define(['jquery', 'log', 'underscore', 'utils'], function($, log, _, utils) {
         if (utils.mozPaymentProvider.iccInfo[paymentServiceId]) {
           iccKey = utils.mozPaymentProvider.iccInfo[paymentServiceId].iccId;
         }
+        console.log('got iccKey from iccInfo', iccKey);
       } else if (utils.mozPaymentProvider.iccIds) {
         // Firefox OS version < 1.4
         iccKey = utils.mozPaymentProvider.iccIds.join(';');
+        console.log('got iccKey from iccIds', iccKey);
       }
 
       if (iccKey) {
         lastIcc = this.storage.getItem('spa-last-icc');
         this.storage.setItem('spa-last-icc', iccKey);
+        console.log('new icc', iccKey, 'saved icc', lastIcc);
         if (lastIcc && lastIcc !== iccKey) {
-          console.log('new icc', iccKey, '!== saved icc', lastIcc);
           changed = true;
           console.log('sim changed');
           utils.trackEvent({'action': 'sim change detection',


### PR DESCRIPTION
@muffinresearch this is WiP but can you think of why we needed to clear localStorage? I think I was the one who added it to Webpay, heh, but I can't think of why we need it. Even for PIN resets I don't think we need it. BTW, does the PIN reset flow work for you? Even without this patch I couldn't get it to work. It stalled on 'Connect to Persona' after I pressed the Continue button on the reset page.
