### PR TITLE
Handle simulated payments (bug 1045905)

### DIFF
--- a/public/js/models/base.js
+++ b/public/js/models/base.js
@@ -1,0 +1,33 @@
+define([
+  'backbone',
+], function(Backbone) {
+
+  'use strict';
+
+  var BaseModel = Backbone.Model.extend({
+
+    sync: function(crudMethod, model, options) {
+      if (model.urlLookup && model.urlLookup[crudMethod]) {
+        var crudMethodData = model.urlLookup[crudMethod];
+        options = options || {};
+        options.url = crudMethodData.url;
+
+        // Set the HTTP method if defined.
+        if (crudMethodData.method) {
+          options.method = crudMethodData.method;
+        }
+        if (crudMethodData.crudMethod) {
+          crudMethod = crudMethodData.crudMethod;
+        }
+      }
+      if (options.data) {
+        options.data = JSON.stringify(options.data);
+        options.contentType = 'application/json';
+        options.dataType = 'json';
+      }
+      return Backbone.sync(crudMethod, model, options);
+    }
+  });
+
+  return BaseModel;
+});

--- a/public/js/models/pin.js
+++ b/public/js/models/pin.js
@@ -1,17 +1,17 @@
 define([
   'jquery',
   'underscore',
-  'backbone',
+  'models/base',
   'log',
   'utils'
-], function($, _, Backbone, log, utils){
+], function($, _, BaseModel, log, utils){
 
   'use strict';
 
   var console = log('model', 'pin');
   var baseApiURL = utils.apiUrl('pin');
 
-  var PinModel = Backbone.Model.extend({
+  var PinModel = BaseModel.extend({
 
     initialize: function(){
       console.log('Initing PinModel');
@@ -36,29 +36,8 @@ define([
       'create': {'url': baseApiURL},
       'read': {'url': baseApiURL},
       'update': {'url': baseApiURL, 'method': 'PATCH'},
-      'check': {'url': baseApiURL + 'check/', 'method': 'POST', 'crudMethod': 'create'},
-    },
-
-    sync: function(crudMethod, model, options) {
-      if (model.urlLookup && model.urlLookup[crudMethod]) {
-        var crudMethodData = model.urlLookup[crudMethod];
-        options = options || {};
-        options.url = crudMethodData.url;
-
-        // Set the HTTP method if defined.
-        if (crudMethodData.method) {
-          options.method = crudMethodData.method;
-        }
-        if (crudMethodData.crudMethod) {
-          crudMethod = crudMethodData.crudMethod;
-        }
-      }
-      if (options.data) {
-        options.data = JSON.stringify(options.data);
-        options.contentType = 'application/json';
-        options.dataType = 'json';
-      }
-      return Backbone.sync(crudMethod, model, options);
+      'check': {'url': baseApiURL + 'check/',
+                'method': 'POST', 'crudMethod': 'create'},
     }
   });
 

--- a/public/js/models/session.js
+++ b/public/js/models/session.js
@@ -15,7 +15,8 @@ define([
 
     defaults: {
       logged_in: null,
-      user_hash: null
+      user_hash: null,
+      simulate_result: null
     },
 
     initialize: function() {

--- a/public/js/models/simulate.js
+++ b/public/js/models/simulate.js
@@ -1,0 +1,25 @@
+define([
+  'jquery',
+  'underscore',
+  'models/base',
+  'utils'
+], function($, _, BaseModel, utils){
+
+  'use strict';
+
+  var baseApiURL = utils.apiUrl('simulate');
+
+  var SimulateModel = BaseModel.extend({
+    url: baseApiURL,
+
+    urlLookup: {
+      'create': {'url': baseApiURL},
+    },
+
+    begin: function() {
+      return this.sync('create', this,  {});
+    },
+  });
+
+  return SimulateModel;
+});

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -13,6 +13,7 @@ define([
   'views/payment-success',
   'views/reset-pin',
   'views/reset-start',
+  'views/simulate',
   'views/wait-to-finish',
   'views/wait-to-start',
   'views/was-locked'
@@ -31,6 +32,7 @@ define([
   PaymentSuccessView,
   ResetPinView,
   ResetStartView,
+  SimulateView,
   WaitToFinishView,
   WaitToStartView,
   WasLockedView
@@ -49,6 +51,7 @@ define([
       'spa/force-auth': 'showForceAuth',
       'spa/reset-pin': 'showResetPin',
       'spa/reset-start': 'showResetStart',
+      'spa/simulate': 'showSimulate',
       'spa/locked': 'showLocked',
       'spa/was-locked': 'showWasLocked',
       'spa/wait-to-start': 'showWaitToStart',
@@ -148,6 +151,10 @@ define([
 
     showResetStart: function() {
       this.viewManager.renderView(ResetStartView);
+    },
+
+    showSimulate: function() {
+      this.viewManager.renderView(SimulateView);
     },
 
     showWaitToFinish: function() {

--- a/public/js/views/app.js
+++ b/public/js/views/app.js
@@ -7,6 +7,7 @@ define([
   'log',
   'models/pin',
   'models/session',
+  'models/simulate',
   'models/transaction',
   'router',
   'settings',
@@ -14,7 +15,9 @@ define([
   'utils',
   'views/throbber',
   'views/error'
-], function(auth, Backbone, cancel, i18n, $, log, PinModel, SessionModel, TransactionModel, AppRouter, settings, _, utils, ThrobberView, ErrorView) {
+], function(auth, Backbone, cancel, i18n, $, log, PinModel, SessionModel,
+            SimulateModel, TransactionModel, AppRouter, settings, _,
+            utils, ThrobberView, ErrorView) {
 
   'use strict';
 
@@ -49,6 +52,7 @@ define([
       // Create Model Instances.
       this.session = new SessionModel();
       this.pin = new PinModel();
+      this.simulate = new SimulateModel();
       this.transaction = new TransactionModel();
 
       // Create overlaid view instances.

--- a/public/js/views/simulate.js
+++ b/public/js/views/simulate.js
@@ -1,0 +1,65 @@
+define([
+  'cancel',
+  'log',
+  'underscore',
+  'utils',
+  'views/page'
+], function(cancel, log, _, utils, PageView){
+
+  'use strict';
+
+  var console = log('view', 'simulate');
+  var SimulateView = PageView.extend({
+
+    events: {
+      'click .cancel': cancel.callPayFailure,
+      'click .cta': 'handleSubmit',
+    },
+
+    handleSubmit: function(e) {
+      if (e) {
+        e.preventDefault();
+      }
+      app.throbber.render(this.gettext('Processing'));
+      console.log('starting simulation');
+      app.simulate.begin().done(function() {
+        utils.trackEvent({action: 'simulate-success',
+                          label: 'Successful simulated payment'});
+        console.log('start simulation succeeded');
+        utils.mozPaymentProvider.paymentSuccess();
+      }).fail(function($xhr, textStatus) {
+        console.error('simulated payment failed');
+        console.error('XHR status', $xhr.status);
+        console.error('response status', textStatus);
+
+        var errorCode;
+        if (textStatus === 'timeout') {
+          utils.trackEvent({action: 'simulate-timeout',
+                            label: 'Simulated payment timed out'});
+          errorCode = 'SIMULATE_TIMEOUT';
+        } else {
+          utils.trackEvent({action: 'simulate-fail',
+                            label: 'Simulated payment failed'});
+          errorCode = 'SIMULATE_FAIL';
+        }
+        return app.error.render({errorCode: errorCode});
+      });
+    },
+
+    render: function() {
+      // TODO: make this page not require a login. bug 1050591.
+      var title = this.gettext('Simulate Payment');
+      this.setTitle(title);
+      this.renderTemplate('simulate.html', {
+        heading: title,
+        msg: this.gettext('You will not be charged.'),
+        simulateResult: JSON.stringify(app.session.get('simulate_result'))
+      });
+      app.throbber.close();
+      return this;
+    }
+
+  });
+
+  return SimulateView;
+});

--- a/public/stylus/_pin.styl
+++ b/public/stylus/_pin.styl
@@ -68,7 +68,8 @@
 }
 
 @media $small-min-width {
-    .pin {
+    .pin,
+    .simulate {
 
         margin: 0 auto;
         max-width: 520px;

--- a/public/stylus/_simulate.styl
+++ b/public/stylus/_simulate.styl
@@ -1,0 +1,3 @@
+.simulate {
+    text-align: center;
+}

--- a/public/stylus/spartacus.styl
+++ b/public/stylus/spartacus.styl
@@ -6,6 +6,7 @@
 @import '_full-error';
 @import '_forms';
 @import '_pin';
+@import '_simulate';
 
 $mp-fonts-path = '../lib/mp-fonts-stylus';
 @import '../lib/mp-fonts-stylus/fonts';

--- a/templates/simulate.html
+++ b/templates/simulate.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% import "_macros.html" as macro %}
+
+{% block pageclass %}simulate{% endblock %}
+
+{% block page %}
+<section class="content">
+  <h1>{{ heading }}</h1>
+  <p>{{ msg }}</p>
+  <p>
+    <pre><code>{{ simulateResult }}</code></pre>
+  </p>
+</section>
+
+{% block buttons %}
+<menu class="buttons" type="toolbar">
+  {{ macro.button(gettext('Cancel'), modifier='cancel') }}
+  {{ macro.button(gettext('Continue'), modifier='cta') }}
+</menu>
+{% endblock %}
+
+{% endblock %}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -323,19 +323,41 @@ function fakeWaitPoll(options) {
 
 
 function fakeStartTransaction(options) {
+  var url = '/mozpay/v1/api/pay/';
   options = options || {};
-  var timeout = options.timeout || false;
-  if (timeout) {
+  options.simulate = options.simulate || false;
+  options.timeout = options.timeout || false;
+
+  if (options.timeout) {
     casper.echo('Setting up an XHR timeout for start of transaction', 'INFO');
-    clientTimeoutResponse('POST', '/mozpay/v1/api/pay/');
+    clientTimeoutResponse('POST', url);
   } else {
     casper.echo('Setting up successful transaction start response', 'INFO');
-    casper.evaluate(function(statusCode) {
-      window.server.respondWith('POST', '/mozpay/v1/api/pay/',
+    casper.evaluate(function(statusCode, url, simulate) {
+      window.server.respondWith('POST', url,
                                 [statusCode,
-                                 {'Content-Type': 'text/plain'}, '']);
+                                 {'Content-Type': 'application/json'},
+                                  JSON.stringify({simulation: simulate,
+                                                  status: 'ok'})]);
 
-    }, options.statusCode || 204);
+    }, options.statusCode || 200, url, options.simulate);
+  }
+}
+
+
+function fakeSimulate(options) {
+  var url = '/mozpay/v1/api/simulate/';
+  options = options || {};
+  options.timeout = options.timeout || false;
+
+  if (options.timeout) {
+    casper.echo('Setting up an XHR timeout for simulate payment', 'INFO');
+    clientTimeoutResponse('POST', url);
+  } else {
+    casper.echo('Setting up successful simulate payment response', 'INFO');
+    casper.evaluate(function(statusCode, url) {
+      window.server.respondWith('POST', url, [statusCode, {}, '']);
+    }, options.statusCode || 204, url);
   }
 }
 
@@ -494,6 +516,7 @@ module.exports = {
   fakeLogout: fakeLogout,
   fakePinData: fakePinData,
   fakeProviderLogout: fakeProviderLogout,
+  fakeSimulate: fakeSimulate,
   fakeStartTransaction: fakeStartTransaction,
   fakeVerification: fakeVerification,
   fakeWaitPoll: fakeWaitPoll,

--- a/tests/ui/test-simulate-error.js
+++ b/tests/ui/test-simulate-error.js
@@ -1,0 +1,29 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  setUp: function(){
+    helpers.fakeVerification();
+    helpers.fakeStartTransaction({simulate: {result: "postback"}});
+    helpers.fakeSimulate({statusCode: 500});
+  },
+});
+
+casper.test.begin('Simulate failure', {
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('simulate'), function() {
+      test.assertVisible('.simulate', 'Simulate page should be displayed');
+      this.click('.cta');
+    });
+
+    casper.waitForSelector('.full-error', function() {
+      helpers.assertErrorCode('SIMULATE_FAIL');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});

--- a/tests/ui/test-simulate-success.js
+++ b/tests/ui/test-simulate-success.js
@@ -1,0 +1,32 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  setUp: function(){
+    helpers.fakeVerification();
+    helpers.fakeStartTransaction({simulate: {result: "postback"}});
+    helpers.fakeSimulate();
+  },
+});
+
+casper.test.begin('Simulate success', {
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('simulate'), function() {
+      test.assertVisible('.simulate', 'Simulate page should be displayed');
+      this.click('.cta');
+    });
+
+    casper.waitForSelector('.full-error', function() {
+      // This is due to no native paymentSuccess function. But it does
+      // show we've reached the success point in the app.
+      // TODO: When a shim is added this will need to be updated.
+      helpers.assertErrorCode('NO_PAY_SUCCESS_FUNC');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});

--- a/tests/ui/test-simulate-timeout.js
+++ b/tests/ui/test-simulate-timeout.js
@@ -1,0 +1,29 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  setUp: function(){
+    helpers.fakeVerification();
+    helpers.fakeStartTransaction({simulate: {result: "postback"}});
+    helpers.fakeSimulate({timeout: true});
+  },
+});
+
+casper.test.begin('Simulate timeout', {
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('simulate'), function() {
+      test.assertVisible('.simulate', 'Simulate page should be displayed');
+      this.click('.cta');
+    });
+
+    casper.waitForSelector('.full-error', function() {
+      helpers.assertErrorCode('SIMULATE_TIMEOUT');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});


### PR DESCRIPTION
@muffinresearch r?

Pretty much same screen as before (which should really look more like a real purchase page):

![simulate](https://cloud.githubusercontent.com/assets/55398/3851093/40697f42-1e90-11e4-8822-a6b154c0e2ee.png)

The Webpay API for this will be added in [bug 1050593](https://bugzilla.mozilla.org/show_bug.cgi?id=1050593)
