### PR TITLE
Show terms and privacy policy if FxA is enabled (bug 1033851)

### DIFF
--- a/public/js/lib/pin-widget.js
+++ b/public/js/lib/pin-widget.js
@@ -19,6 +19,7 @@ define([
   var $errorMessage;
   var $content;
   var $forgotPin;
+  var $terms;
 
   function getPin() {
     return pinBuffer;
@@ -39,6 +40,9 @@ define([
   function updatePinUI() {
     console.log('Updating pin UI');
     var numFilled = pinBuffer.length;
+    if (numFilled >= 1) {
+      $terms.addClass('hidden');
+    }
     $pseudoInputs.each(function(index, elm) {
       var $elm = $(elm);
       if (index + 1 <= numFilled) {
@@ -75,6 +79,7 @@ define([
     $errorMessage.text(errorMessage);
     $errorMessage.removeClass('hidden');
     $forgotPin.addClass('hidden');
+    $terms.addClass('hidden');
     focusPin();
   }
 
@@ -91,6 +96,7 @@ define([
     $submitButton = $('.cta[type=submit]');
     $errorMessage = $('.err-msg');
     $forgotPin = $('.forgot-pin');
+    $terms = $('.terms');
     $content = $('.content');
     $content.on('click', function(e) {
       focusPin();

--- a/public/js/views/create-pin.js
+++ b/public/js/views/create-pin.js
@@ -110,7 +110,8 @@ define([
     render: function(){
       var context = {
         ctaText: this.gettext('Continue'),
-        pinTitle: this.gettext('Create PIN')
+        pinTitle: this.gettext('Create PIN'),
+        showFxATerms: utils.bodyData.fxaUrl
       };
       this.setTitle(this.gettext('Create PIN'));
       this.renderTemplate('pin-form.html', context);

--- a/public/stylus/spartacus.styl
+++ b/public/stylus/spartacus.styl
@@ -167,6 +167,7 @@ main,
 }
 
 @media $small-min-width {
+    .terms,
     .forgot-pin a,
     .err-msg {
         font-size: 14px;

--- a/templates/pin-form.html
+++ b/templates/pin-form.html
@@ -14,6 +14,11 @@
       <span></span>
       <span></span>
     </div>
+    {% if showFxATerms -%}
+      <p class="terms">{{ format(gettext('By proceeding you agree to our <a href="%(terms)s">terms</a> and <a href="%(privacy)s">Privacy Policy</a>'), {
+            'terms': 'https://marketplace.firefox.com/terms-of-use',
+            'privacy': 'https://marketplace.firefox.com/privacy-policy' }, true)|safe }}</p>
+    {%- endif %}
     {% if showForgotPin -%}
       <p class="forgot-pin"><a href="#">{{ gettext('Forgot your PIN?') }}</a></p>
     {%- endif %}

--- a/tests/ui/test-create-pin-204.js
+++ b/tests/ui/test-create-pin-204.js
@@ -16,6 +16,7 @@ casper.test.begin('Login successful pin creation.', {
 
     casper.waitForUrl(helpers.url('create-pin'), function() {
       test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+      test.assertDoesntExist('.terms', 'Terms are not visible on create-pin if not FxA enabled');
       this.sendKeys('.pinbox', '1234');
       test.assertExists('.cta:enabled', 'Submit button is enabled');
       this.click('.cta');

--- a/tests/ui/test-fxa-reset-pin-204.js
+++ b/tests/ui/test-fxa-reset-pin-204.js
@@ -16,6 +16,7 @@ casper.test.begin('Reset pin returns 204, then onto wait for tx.', {
     helpers.doLogin();
     // On enter pin page click forgot pin link.
     casper.waitForUrl(helpers.url('enter-pin'), function() {
+      test.assertDoesntExist('.terms', 'Terms are not visible on enter-pin');
       this.click('.forgot-pin a');
     });
 

--- a/tests/ui/test-fxa-terms-onerror.js
+++ b/tests/ui/test-fxa-terms-onerror.js
@@ -1,0 +1,31 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  useFxA: true,
+  setUp: function(){
+    helpers.fakeFxA();
+    helpers.fakeStartTransaction();
+    helpers.fakePinData({data: {pin: false}});
+  }
+});
+
+casper.test.begin('Check FxA terms links', {
+
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('create-pin'), function() {
+      test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+      test.assertDoesntExist('.forgot-pin', 'No forgot-pin should be present for pin creation');
+      test.assertVisible('.terms', 'Terms and privacy policy urls should be present.');
+      this.sendKeys('.pinbox', 'a');
+      test.assertNotVisible('.terms', 'Terms are removed when error is shown');
+      test.assertVisible('.err-msg', 'Error message is displayed');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});

--- a/tests/ui/test-fxa-terms.js
+++ b/tests/ui/test-fxa-terms.js
@@ -1,0 +1,30 @@
+var helpers = require('../helpers');
+
+helpers.startCasper({
+  useFxA: true,
+  setUp: function(){
+    helpers.fakeFxA();
+    helpers.fakeStartTransaction();
+    helpers.fakePinData({data: {pin: false}});
+  }
+});
+
+casper.test.begin('Check FxA terms links', {
+
+  test: function(test) {
+
+    helpers.doLogin();
+
+    casper.waitForUrl(helpers.url('create-pin'), function() {
+      test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
+      test.assertDoesntExist('.forgot-pin', 'No forgot-pin should be present for pin creation');
+      test.assertVisible('.terms', 'Terms and privacy policy urls should be present.');
+      this.sendKeys('.pinbox', '1');
+      test.assertNotVisible('.terms', 'Terms are removed when first char is entered');
+    });
+
+    casper.run(function() {
+      test.done();
+    });
+  },
+});


### PR DESCRIPTION
Add the terms and privacy policy links on create-pin if FxA is enabled (based on the data attr)

![firefox_os_simulator](https://cloud.githubusercontent.com/assets/1514/3937583/10baacec-24af-11e4-9acc-b383b8874fdb.png)

It gets dismissed as soon as you type a char or cause an error (so there's room for the error).
