### PR TITLE
Fix path usage for docker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -265,28 +265,22 @@ module.exports = function(grunt) {
   // Always show stack traces when Grunt prints out an uncaught exception.
   grunt.option('stack', true);
 
-  // Workaround having node_modules in parent dir for Docker.
-  var cwd;
   if (process.env.IS_DOCKER) {
-    cwd = process.cwd();
-    process.chdir(__dirname);
-  }
-
-  grunt.loadNpmTasks('grunt-bower-task');
-  grunt.loadNpmTasks('grunt-casper');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-requirejs');
-  grunt.loadNpmTasks('grunt-contrib-stylus');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-env');
-  grunt.loadNpmTasks('grunt-nunjucks');
-  grunt.loadNpmTasks('grunt-shell');
-  grunt.loadNpmTasks('grunt-i18n-abide');
-  grunt.loadNpmTasks('grunt-express-server');
-
-  if (cwd && process.env.IS_DOCKER) {
-    process.chdir(cwd);
+    // Workaround having node_modules in parent dir for Docker.
+    grunt.file.expand('../node_modules/grunt-*/tasks').forEach(grunt.loadTasks);
+  } else {
+    grunt.loadNpmTasks('grunt-bower-task');
+    grunt.loadNpmTasks('grunt-casper');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-requirejs');
+    grunt.loadNpmTasks('grunt-contrib-stylus');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-env');
+    grunt.loadNpmTasks('grunt-nunjucks');
+    grunt.loadNpmTasks('grunt-shell');
+    grunt.loadNpmTasks('grunt-i18n-abide');
+    grunt.loadNpmTasks('grunt-express-server');
   }
 
   grunt.registerTask('default', 'Does the same thing as grunt start', ['start']);

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ var crypto = require('crypto');
 var express = require('express');
 var i18n = require('i18n-abide');
 var nunjucks = require('nunjucks');
+var path = require('path');
 var rewriteModule = require('http-rewrite-middleware');
 
 // Node only config.
@@ -39,7 +40,7 @@ spa.use(i18n.abide({
   supported_languages: settings.supportedLanguages,
   debug_lang: 'db-LB',
   default_lang: 'en-US',
-  translation_directory: 'public/i18n'
+  translation_directory: path.join(__dirname, 'public/i18n')
 }));
 
 spa.use(rewriteModule.getMiddleware([


### PR DESCRIPTION
Fix the way paths are handled for docker. This is due to the necessity of needing to have node_modules installed above the /srv/spartacus/src so that we don't create any symlinks in the vbox-shared folders (as symlinks are disabled by default).
