### PR TITLE
Echo testing errors

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -29,6 +29,17 @@ function makeToken() {
   return Math.random().toString(36).slice(2);
 }
 
+casper.on('page.error', function(error, trace) {
+    if (error.indexOf('INVALID_STATE_ERR') !== -1) {
+      casper.echo(error, 'WARNING');
+    } else {
+      var lines = [error];
+      trace.forEach(function(line) {
+          lines.push([line.file, 'line', line.line].join(' '));
+      });
+      casper.echo(lines.join('\n'), 'ERROR');
+    }
+});
 
 casper.on('page.initialized', function(page) {
   if (!_testInited[_currTestId]) {
@@ -476,6 +487,7 @@ function startCasper(options) {
     casper.echo('Starting tearDown');
     casper.echo('Tearing down Sinon', 'INFO');
     casper.evaluate(function(consumeStack) {
+      if (!window.server) return;
       if (consumeStack && window.server._oldProcessRequest) {
         console.log('restoring server.processRequest');
         window.server.processRequest = window.server._oldProcessRequest;


### PR DESCRIPTION
There was an error causing the FxA reverification timeout/500 tests to fail. This adds some logging so that we can notice when errors are happening.

We get a bunch of errors that have `INVALID_STATE_ERR` in them, these appear to come from forcing timeouts. I couldn't come up with a way of preventing the error so I made it just log the message.

![screenshot 2014-10-24 11 44 19](https://cloud.githubusercontent.com/assets/211578/4772935/205d1304-5b9d-11e4-8a43-2e69dd467da4.png)

> Error occurred

![screenshot 2014-10-24 11 44 02](https://cloud.githubusercontent.com/assets/211578/4772936/2063ef26-5b9d-11e4-8174-4e21c173b1a8.png)

> Error fixed
