### PR TITLE
Better error when client cannot configure trans.

### DIFF
--- a/public/js/views/page.js
+++ b/public/js/views/page.js
@@ -185,7 +185,7 @@ define([
             utils.trackEvent({action: 'start-transaction',
                               label: 'Transaction failed to start'});
             return app.error.render(
-              {errorCode: utils.errorCodeFromXhr($xhr, 'TRANS_CONFIG_FAILED')});
+              {errorCode: utils.errorCodeFromXhr($xhr, 'TRANS_REQUEST_FAILED')});
           }
         });
 

--- a/tests/ui/test-start-transaction-failure.js
+++ b/tests/ui/test-start-transaction-failure.js
@@ -15,7 +15,7 @@ casper.test.begin('Transaction failure should only have cancel option.', {
     helpers.doLogin();
 
     casper.waitForSelector('.full-error', function() {
-      helpers.assertErrorCode('TRANS_CONFIG_FAILED');
+      helpers.assertErrorCode('TRANS_REQUEST_FAILED');
       test.assertVisible('.full-error .button', 'Cancel button should be visible');
       test.assertElementCount('.full-error .button', 1, 'Should only be one button for cancelling the flow');
       casper.click('.full-error .button');


### PR DESCRIPTION
Use a different error code to differentiate from the
server errors that could happen.
