### PR TITLE
Add timeout for postMessage failures (bug 1112190)

### DIFF
--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -94,11 +94,13 @@ define(['utils', 'settings'], function(utils, settings) {
           render: function() {},
         }
       };
+      this.clock = sinon.useFakeTimers();
     });
 
     teardown(function(){
       window.opener = this.oldWindowOpener;
       window.app = this.oldApp;
+      this.clock.restore();
     });
 
     test('test paymentSuccess', function() {
@@ -128,6 +130,21 @@ define(['utils', 'settings'], function(utils, settings) {
       utils.mozPaymentProvider.paymentFailed();
       sinon.assert.calledWith(stubError, sinon.match({errorCode: 'INCOMPLETE_PAY_FAIL'}));
     });
+
+   test('test paymentSuccess timeout', function() {
+      var stubError = sinon.stub(window.app.error, 'render');
+      utils.mozPaymentProvider.paymentSuccess();
+      this.clock.tick(3000);
+      sinon.assert.calledWith(stubError, sinon.match({errorCode: 'PAY_SUCCESS_TIMEOUT'}));
+    });
+
+    test('test paymentFailed timeout', function() {
+      var stubError = sinon.stub(window.app.error, 'render');
+      utils.mozPaymentProvider.paymentFailed();
+      this.clock.tick(3000);
+      sinon.assert.calledWith(stubError, sinon.match({errorCode: 'PAY_FAILURE_TIMEOUT'}));
+    });
+
   });
 
 


### PR DESCRIPTION
r? @kumar303 

Following on fromt the last patch this DRY's up the errors and adds a timeout for the case where the postMessage doesn't close the window for whatever reason.

This will need error messages added in webpay for devs.

Does 3secs seem ok? postMessages should be fast I would have thought.

I'm not checking for the cancelCallback being called here since we mocked out the app.error.render and that's now covered in the error unit tests anyway.