### PR TITLE
Add try/catch for mozId (bug 1123849)

### DIFF
--- a/public/js/lib/utils.js
+++ b/public/js/lib/utils.js
@@ -122,6 +122,17 @@ define([
       }
       return false;
     },
+    hasMozId: function(nav) {
+      nav = nav || navigator;
+      var mozId;
+      try {
+        mozId = nav.mozId;
+      } catch(e) {
+        // Handle exception due to bug 1129650
+        logger.error(e);
+      }
+      return typeof mozId !== 'undefined';
+    },
     supportsNativeFxA: function(nav) {
       // Until Native FxA is ready, let's not check this.
       if (!settings.enableNativeFxA) {
@@ -131,7 +142,7 @@ define([
         // native FxA support.
         nav = nav || navigator;
         var uaMatch = nav.userAgent.match(/rv:(\d{2})/);
-        var hasNativeFxA = this.bodyData.fxaAuthUrl && nav.mozId && uaMatch && uaMatch[1] >= 34;
+        var hasNativeFxA = this.bodyData.fxaAuthUrl && utils.hasMozId(nav) && uaMatch && uaMatch[1] >= 34;
         return hasNativeFxA;
       }
     },

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -180,7 +180,27 @@ define(['utils', 'settings'], function(utils, settings) {
         mozId: {},
         userAgent: 'Mozilla/5.0 (Mobile; rv:34.0) Gecko/26.0 Firefox/34.0'
       }));
+
+      assert.notOk(utils.supportsNativeFxA({
+        userAgent: 'Mozilla/5.0 (Mobile; rv:34.0) Gecko/26.0 Firefox/34.0'
+      }));
     });
+
+
+    test('hasMozID util', function() {
+      assert.equal(utils.hasMozId({
+        get mozId(){
+          throw new Error('AWOOGA');
+        }
+      }), false);
+
+      assert.equal(utils.hasMozId({
+        mozId: {}
+      }), true);
+
+      assert.equal(utils.hasMozId({}), false);
+    });
+
 
     test('test native-FxA UA detection when enableNativeFxA is false', function() {
       settings.enableNativeFxA = false;


### PR DESCRIPTION
This catches the exception from introspecting navigator.mozId but there are additional errors beyond this that are now revealed in FF Android. :(