### PR TITLE
Support native FxA on 2.0 (bug 1131732)

### DIFF
--- a/public/js/lib/utils.js
+++ b/public/js/lib/utils.js
@@ -142,7 +142,7 @@ define([
         // native FxA support.
         nav = nav || navigator;
         var uaMatch = nav.userAgent.match(/rv:(\d{2})/);
-        var hasNativeFxA = this.bodyData.fxaAuthUrl && utils.hasMozId(nav) && uaMatch && uaMatch[1] >= 34;
+        var hasNativeFxA = this.bodyData.fxaAuthUrl && utils.hasMozId(nav) && uaMatch && uaMatch[1] >= 32;
         return hasNativeFxA;
       }
     },

--- a/tests/unit/test-utils.js
+++ b/tests/unit/test-utils.js
@@ -171,18 +171,13 @@ define(['utils', 'settings'], function(utils, settings) {
         userAgent: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0'
       }));
 
-      assert.notOk(utils.supportsNativeFxA({
-        mozId: {},
-        userAgent: 'Mozilla/5.0 (Mobile; rv:32.0) Gecko/26.0 Firefox/32.0'
-      }));
-
       assert.ok(utils.supportsNativeFxA({
         mozId: {},
-        userAgent: 'Mozilla/5.0 (Mobile; rv:34.0) Gecko/26.0 Firefox/34.0'
+        userAgent: 'Mozilla/5.0 (Mobile; rv:34.0) Gecko/26.0 Firefox/32.0'
       }));
 
       assert.notOk(utils.supportsNativeFxA({
-        userAgent: 'Mozilla/5.0 (Mobile; rv:34.0) Gecko/26.0 Firefox/34.0'
+        userAgent: 'Mozilla/5.0 (Mobile; rv:34.0) Gecko/26.0 Firefox/32.0'
       }));
     });
 


### PR DESCRIPTION
Turns out 2.0 supports native FxA for privileged apps now.