### PR TITLE
Show PIN too short error on early submission (bug 1102888)

### DIFF
--- a/public/js/lib/pin-widget.js
+++ b/public/js/lib/pin-widget.js
@@ -9,6 +9,8 @@ define([
   'use strict';
 
   var backspace = 8;
+  var enterKeyCode = 13;
+
   var logger = log('lib', 'pin-widget');
   var pinMaxLength = 4;
   var pinBuffer = '';
@@ -60,6 +62,15 @@ define([
   function handleKeyPress(e) {
     var key = String.fromCharCode(e.charCode);
     var keyCode = e.keyCode;
+
+    // Show an error if enter is used to submit when the number of chars
+    // is less that pinMaxLength
+    if (keyCode === enterKeyCode && pinBuffer.length !== pinMaxLength) {
+      utils.trackEvent({'action': 'pin form',
+                        'label': 'Pin Error Displayed'});
+      showError(i18n.gettext('PIN too short'), {showForgotPin: true});
+      return false;
+    }
 
     // Don't prevent non-char keys save for backspace which we handle
     // specially.

--- a/tests/ui/test-create-pin-enter-submit.js
+++ b/tests/ui/test-create-pin-enter-submit.js
@@ -17,7 +17,15 @@ casper.test.begin('Check Create PIN submission on enter', {
 
     casper.waitForUrl(helpers.url('create-pin'), function() {
       test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
-      this.sendKeys('.pinbox', '1234');
+      this.sendKeys('.pinbox', '12', {keepFocus: true});
+      test.assertNotExists('.cta:enabled', 'Submit button is enabled');
+      // This way of submitting enter is required for the keyCode to be caught.
+      // helpers.sendEnterKey doesn't work in this case.
+      this.sendKeys('.pinbox', casper.page.event.key.Enter);
+      test.assertVisible('.err-msg', 'Error message should be visible on too short input.');
+      test.assertNotVisible('.forgot-pin', 'Forgot PIN should not be shown on create-pin screen');
+      this.sendKeys('.pinbox', '34', {keepFocus: true});
+      test.assertNotVisible('.err-msg', 'Error message should be gone');
       test.assertExists('.cta:enabled', 'Submit button is enabled');
       helpers.sendEnterKey('.pinbox');
     });

--- a/tests/ui/test-enter-pin-200.js
+++ b/tests/ui/test-enter-pin-200.js
@@ -17,7 +17,18 @@ casper.test.begin('Enter Pin API call returns 200', {
 
     casper.waitForUrl(helpers.url('enter-pin'), function() {
       test.assertVisible('.pinbox', 'Pin entry widget should be displayed');
-      this.sendKeys('.pinbox', '1234');
+      this.sendKeys('.pinbox', '12', {keepFocus: true});
+      test.assertNotExists('.cta:enabled', 'Submit button is not enabled');
+      // This way of submitting enter is required for the keyCode to be caught.
+      // helpers.sendEnterKey doesn't work in this case.
+      this.sendKeys('.pinbox', casper.page.event.key.Enter);
+    });
+
+    casper.waitUntilVisible('.err-msg', function() {
+      test.assertVisible('.err-msg', 'Error message should be visible on too short input.');
+      test.assertVisible('.forgot-pin', 'Forgot PIN should be shown on enter-pin screen');
+      this.sendKeys('.pinbox', '34');
+      test.assertNotVisible('.err-msg', 'Error message should be gone');
       test.assertExists('.cta:enabled', 'Submit button is enabled');
       this.click('.cta');
       test.assertExists('.cta:disabled', 'Submit button is disabled on click');


### PR DESCRIPTION
This shows a PIN too short error when the enter key is used to submit before the entire PIN has been entered.

![out2](https://cloud.githubusercontent.com/assets/1514/6174446/ad92b97c-b2e6-11e4-8152-d2e9446bad75.gif)
