### PR TITLE
Add error page CSS for webpay served errors (bug 1135656)

### DIFF
--- a/public/stylus/spartacus.styl
+++ b/public/stylus/spartacus.styl
@@ -202,3 +202,21 @@ html[dir="rtl"] .button {
         text-align: center;
     }
 }
+
+/* The webpay error pags 403/404/500 etc */
+.error-page {
+
+    background: $pale-gray;
+    padding: 20px;
+
+    h1 {
+        border: none;
+        font-size: 2em;
+        margin: 0.5em 0;
+    }
+
+    p {
+        font-size: 14px;
+        line-height: 22px;
+    }
+}


### PR DESCRIPTION
Add the CSS for webpay's hosted error pages.