### PR TITLE
Truncate long errors to avoid breaking the layout (bug 1151774)

### DIFF
--- a/public/stylus/_full-error.styl
+++ b/public/stylus/_full-error.styl
@@ -51,6 +51,8 @@
         .error-code {
             color: $dark-gray;
             text-shadow: 0 1px 0 $medium-gray;
+            display: -moz-box;
+            overflow: hidden;
         }
     }
 

--- a/styleguide/context.js
+++ b/styleguide/context.js
@@ -5,7 +5,7 @@ module.exports = {
     pageclass: 'full-error',
     heading: "Error Heading",
     msg: "An error message telling the user what happened",
-    errorCode: "ERROR_CODE",
+    errorCode: "ERROR_CODE_TOO_LONG_DOESNT_FIT",
     cancelModifier: 'cancel cta',
     cancelText: 'Cancel',
     showCancel: true,


### PR DESCRIPTION
The fix is a compromise so that it works on FF18+. The reccommendation will be to keep message length down to avoid this but at least this will prevent the layout being broken.

Before:
![styleguide](https://cloud.githubusercontent.com/assets/1514/6971837/4125d3f2-d977-11e4-9337-7682ae8ec8e3.png)

After: 

FF18:

![styleguide](https://cloud.githubusercontent.com/assets/1514/6971842/52c84bbc-d977-11e4-9a34-291c0c906368.png)

FF 36.04

![styleguide](https://cloud.githubusercontent.com/assets/1514/6971858/6ad1abea-d977-11e4-97e6-c832328683da.png)

Chrome:

![styleguide](https://cloud.githubusercontent.com/assets/1514/6971865/795ed4c6-d977-11e4-9ae0-03b593be1d1e.png)

